### PR TITLE
Print command output's repr() instead of str()

### DIFF
--- a/python-console/pc.py
+++ b/python-console/pc.py
@@ -326,7 +326,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             try:
                 r = eval(command, self.namespace, self.namespace)
                 if r is not None:
-                    print(r)
+                    print(repr(r))
             except SyntaxError:
                 exec(command, self.namespace)
         except:


### PR DESCRIPTION
This is how the original python console behaves. Using `repr` disambiguates output for certain types, such as `str`.

Example before this commit: input is `str`, but output looks like `bool`:
```
>>> 'True'
True
```

Example after this commit:
```
>>> 'True'
'True'
```